### PR TITLE
Fix images

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,7 +6,7 @@ import Seo from "../components/seo";
 // coponents
 import data from "../../data/data.yaml";
 import Layout from "../components/layout";
-import Tutcard from "../components/tutCard";
+import Tutcard from "../components/tutcard";
 
 
 // styles


### PR DESCRIPTION
This was a confusing bug, and it took me a while to figure out what was wrong. It turned out that the filename in the import had a capitalized letter, which was somehow fine for some things, but not for images. Closes #8.
