### PR TITLE
Make tutorial cards clickable

### DIFF
--- a/src/components/tutcard.js
+++ b/src/components/tutcard.js
@@ -12,62 +12,64 @@ import { MdVideoLibrary } from "react-icons/md";
 // markup
 const Tutcard = ({ tut }) => {
   return (
-    <div className="tutCard">
-      {/* GitHub and Videos links */}
-      <div className="additionals">
-        {tut.repository !== "" ? (
-          <a title="GitHub Repo" href={tut.repository}>
-            <AiFillGithub height={300} />
-            <span style={{ marginLeft: "8px" }}>GitHub</span>
+    <a href={tut.webpage}>
+      <div className="tutCard">
+        {/* GitHub and Videos links */}
+        <div className="additionals">
+          {tut.repository !== "" ? (
+            <a title="GitHub Repo" href={tut.repository}>
+              <AiFillGithub height={300} />
+              <span style={{ marginLeft: "8px" }}>GitHub</span>
+            </a>
+          ) : null}
+        </div>
+        <div className="videos">
+          {tut.videos !== "" ? (
+            <a title="Videos" href={tut.videos}>
+              <MdVideoLibrary height={300} />
+              <span style={{ marginLeft: "8px" }}>Videos</span>
+            </a>
+          ) : null}
+        </div>
+
+        {/* hero-image */}
+        <div className="tutCardImg">
+          <StaticImage
+            className="hero-image"
+            src="../images/clifford.jpg"
+            height={300}
+            alt={tut.name}
+          ></StaticImage>
+        </div>
+
+        {/* texts */}
+        <div className="tutCardText">
+          {/* title */}
+          <a title={tut.name} href={tut.webpage}>
+            <h3>{parse(tut.name)}</h3>
           </a>
-        ) : null}
-      </div>
-      <div className="videos">
-        {tut.videos !== "" ? (
-          <a title="Videos" href={tut.videos}>
-            <MdVideoLibrary height={300} />
-            <span style={{ marginLeft: "8px" }}>Videos</span>
-          </a>
-        ) : null}
-      </div>
 
-      {/* hero-image */}
-      <div className="tutCardImg">
-        <StaticImage
-          className="hero-image"
-          src="../images/clifford.jpg"
-          height={300}
-          alt={tut.name}
-        ></StaticImage>
+          {/* description */}
+          <p>{parse(tut.description)}</p>
+        </div>
+        <div
+          className={`status ${
+            tut.status === "stable"
+              ? "stable"
+              : tut.status === "beta"
+                ? "beta"
+                : "alpha"
+          }`}
+          title={
+            tut.status === "stable"
+              ? "stable"
+              : tut.status === "beta"
+                ? "beta"
+                : "alpha"
+          }
+        ></div>
       </div>
-
-      {/* texts */}
-      <div className="tutCardText">
-        {/* title */}
-        <a title={tut.name} href={tut.webpage}>
-          <h3>{parse(tut.name)}</h3>
-        </a>
-
-        {/* description */}
-        <p>{parse(tut.description)}</p>
-      </div>
-      <div
-        className={`status ${
-          tut.status === "stable"
-            ? "stable"
-            : tut.status === "beta"
-              ? "beta"
-              : "alpha"
-        }`}
-        title={
-          tut.status === "stable"
-            ? "stable"
-            : tut.status === "beta"
-              ? "beta"
-              : "alpha"
-        }
-      ></div>
-    </div>
+    </a>
   );
 };
 


### PR DESCRIPTION
It feels more modern to me to be able to click anywhere on the tutorial card to access the website, instead of having to click on the title. I think it's especially relevant for tablets or phones where it's not as easy to tell what's clickable, and it seems intuitive to me to be able to just tap the card.

I can understand if people disagree with this, so feel free to reject the PR if you don't like it.

(The diff shows a bunch of changes, but I just added two lines and fixed indentation.)