### PR TITLE
Make non-stable status more visible

### DIFF
--- a/src/components/tutcard.js
+++ b/src/components/tutcard.js
@@ -20,6 +20,18 @@ const Tutcard = ({ tut }) => {
       handleCardClick();
     }
   };
+
+  const statusDescriptionMapping = {
+    stable: "",
+    beta: "Beta testing",
+    alpha: "Early development",
+  };
+  const statusClassMapping = {
+    stable: "",
+    beta: "status beta",
+    alpha: "status alpha",
+  };
+
   return (
     <div
       className="tutCard"
@@ -67,16 +79,9 @@ const Tutcard = ({ tut }) => {
         {/* description */}
         <p>{parse(tut.description)}</p>
       </div>
-      {tut.status === "stable" ? (
-        ""
-      ) : (
-        <div
-          className={`status ${tut.status === "beta" ? "beta" : "alpha"}`}
-          title={tut.status === "beta" ? "beta" : "alpha"}
-        >
-          {tut.status === "beta" ? "Beta testing" : "Early development"}
-        </div>
-      )}
+      <div className={statusClassMapping[tut.status]} title={tut.status}>
+        {statusDescriptionMapping[tut.status]}
+      </div>
     </div>
   );
 };

--- a/src/components/tutcard.js
+++ b/src/components/tutcard.js
@@ -67,24 +67,16 @@ const Tutcard = ({ tut }) => {
         {/* description */}
         <p>{parse(tut.description)}</p>
       </div>
-      { tut.status === "stable" ? "" :
+      {tut.status === "stable" ? (
+        ""
+      ) : (
         <div
-          className={`status ${
-            tut.status === "beta"
-              ? "beta"
-              : "alpha"
-          }`}
-          title={
-            tut.status === "beta"
-              ? "beta"
-              : "alpha"
-          }
-        >{
-          tut.status === "beta"
-              ? "Beta testing"
-              : "Early development"
-        }</div>
-      }
+          className={`status ${tut.status === "beta" ? "beta" : "alpha"}`}
+          title={tut.status === "beta" ? "beta" : "alpha"}
+        >
+          {tut.status === "beta" ? "Beta testing" : "Early development"}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/tutcard.js
+++ b/src/components/tutcard.js
@@ -67,22 +67,24 @@ const Tutcard = ({ tut }) => {
         {/* description */}
         <p>{parse(tut.description)}</p>
       </div>
-      <div
-        className={`status ${
-          tut.status === "stable"
-            ? "stable"
-            : tut.status === "beta"
+      { tut.status === "stable" ? "" :
+        <div
+          className={`status ${
+            tut.status === "beta"
               ? "beta"
               : "alpha"
-        }`}
-        title={
-          tut.status === "stable"
-            ? "stable"
-            : tut.status === "beta"
+          }`}
+          title={
+            tut.status === "beta"
               ? "beta"
               : "alpha"
-        }
-      ></div>
+          }
+        >{
+          tut.status === "beta"
+              ? "Beta testing"
+              : "Early development"
+        }</div>
+      }
     </div>
   );
 };


### PR DESCRIPTION
I added a larger status badge, as discussed in #7. Here is how it looks.


![Screenshot 2023-12-21 at 11 10 19 AM](https://github.com/hsf-training/training-center/assets/7596837/5086db0f-4888-4058-a6fe-633b26016b52)

Closes #7