### PR TITLE
feat: add analytics

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,11 +23,15 @@ jobs:
       - name: Install node dependencies
         run: npm install
       - name: Build site
-        run: npm run build
+        run: |
+          PREFIX_PATHS=true npm run build
+          mkdir website
+          mv public website/training-center
+          cp redirect.html website/index.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./public
+          path: ./website
   deploy:
     if: github.event_name == 'push'
     needs: build

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  pathPrefix: `/training-center`,
   siteMetadata: {
     siteUrl: "https://hsf-training.org",
     title: "HSF Training Center",

--- a/redirect.html
+++ b/redirect.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta charset="UTF-8" />

--- a/redirect.html
+++ b/redirect.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="0; url=/training-center/">
+        <script type="text/javascript">
+            window.location.href = "/training-center/"
+        </script>
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        If you are not redirected automatically, follow this <a href='/training-center/'>link to the training center.</a>.
+    </body>
+</html>

--- a/redirect.html
+++ b/redirect.html
@@ -1,14 +1,15 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html lang="en-US">
-    <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="refresh" content="0; url=/training-center/">
-        <script type="text/javascript">
-            window.location.href = "/training-center/"
-        </script>
-        <title>Page Redirection</title>
-    </head>
-    <body>
-        If you are not redirected automatically, follow this <a href='/training-center/'>link to the training center.</a>.
-    </body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=/training-center/" />
+    <script type="text/javascript">
+      window.location.href = "/training-center/";
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, follow this
+    <a href="/training-center/">link to the training center.</a>.
+  </body>
 </html>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -15,6 +15,7 @@ const Layout = ({ pageTitle, children }) => {
     <>
       <header>
         <title>{pageTitle}</title>
+        <script defer data-domain="hepsoftwarefoundation.org" src="https://views.scientific-python.org/js/script.js"></script>
       </header>
       {/* navbar */}
       <nav>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -15,7 +15,11 @@ const Layout = ({ pageTitle, children }) => {
     <>
       <header>
         <title>{pageTitle}</title>
-        <script defer data-domain="hepsoftwarefoundation.org" src="https://views.scientific-python.org/js/script.js"></script>
+        <script
+          defer
+          data-domain="hepsoftwarefoundation.org"
+          src="https://views.scientific-python.org/js/script.js"
+        ></script>
       </header>
       {/* navbar */}
       <nav>


### PR DESCRIPTION
This PR makes some changes so that we can use Plausible Analytics along with the main HSF website. The script was added to the layout file. We needed to move everything into a directory since otherwise the traffic would be reported as if it was on the root of the main HSF website. An HTML file with a redirect to `/training-center` was added, since with the current DNS we can't set a 301/302 redirect for a single page. We'll test to see if this works and we might adjust it later.
