### PR TITLE
Fix hyperlinks pointing to HSF training group page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## The project
 
-There is a large number of training resources for newcomers in the field of High Energy Physics. The [HSF Training group](https://hepsoftwarefoundation.org/workinggroups/training.html) together with [IRIS-HEP](https://iris-hep.org/) has started to compile a curriculum of such training modules that helps to get beginners up to speed quickly. However, the [current listing](https://hepsoftwarefoundation.org/training/curriculum.html) in the form of a static table is quickly becoming overwhelming, and we cannot include many resources because of space limitations.
+There is a large number of training resources for newcomers in the field of High Energy Physics. The [HSF Training group](https://hepsoftwarefoundation.org/activities/training.html) together with [IRIS-HEP](https://iris-hep.org/) has started to compile a curriculum of such training modules that helps to get beginners up to speed quickly. However, the [current listing](https://hepsoftwarefoundation.org/training/curriculum.html) in the form of a static table is quickly becoming overwhelming, and we cannot include many resources because of space limitations.
 
 This project is about creating a new training center that turns the static page into a dynamic list of training content that can be filtered by attributes such as programming language, common tasks, type of training, HEP experiment, etc.
 

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -55,7 +55,7 @@ const Layout = ({ pageTitle, children }) => {
             </li>
             <li className="navLinkItem">
               <a
-                href="https://hepsoftwarefoundation.org/workinggroups/training.html"
+                href="https://hepsoftwarefoundation.org/activities/training.html"
                 target="_blank"
                 rel="noopener noreferrer"
                 title="About"

--- a/src/pages/contribute.js
+++ b/src/pages/contribute.js
@@ -30,7 +30,7 @@ const ContributePage = () => {
           Join our <b>meetings</b> to give feedback and discuss with us (details
           at our{" "}
           <a
-            href="https://hepsoftwarefoundation.org/workinggroups/training.html"
+            href="https://hepsoftwarefoundation.org/activities/training.html"
             className="a-no-style"
           >
             main page


### PR DESCRIPTION
The current URL provided yields a 404 page not found error. The correct link is https://hepsoftwarefoundation.org/activities/training.html