### PR TITLE
Update Git tutorial link

### DIFF
--- a/data/data.yaml
+++ b/data/data.yaml
@@ -283,10 +283,10 @@
   level:
     - beginner
   name: Version controlling with git
-  repository: https://github.com/swcarpentry/git-novice
+  repository: https://github.com/hsf-training/git-novice
   status: stable
   videos: ""
-  webpage: http://swcarpentry.github.io/git-novice
+  webpage: https://hsf-training.github.io/git-novice
   image: git-logo.svg
   language:
     - other


### PR DESCRIPTION
I updated the links so that we use our own fork of the material instead of the original SoftwareCarpentries one.