### PR TITLE
Sitemap generation for training catalog to fetch HSF material

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "gatsby"
   ],
   "scripts": {
-    "develop": "gatsby develop",
+    "develop:sitemap": "./src/scripts/generate-sitemap.sh",
+    "develop": "npm run develop:sitemap && gatsby develop",
     "start": "gatsby develop",
-    "build": "gatsby build",
+    "build:sitemap": "./src/scripts/generate-sitemap.sh",
+    "build": "npm run build:sitemap && gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean"
   },
@@ -28,6 +30,7 @@
     "html-react-parser": "^5.0.0",
     "react-icons": "^4.8.0",
     "react-select": "^5.7.0",
-    "react-tabs": "^6.0.2"
+    "react-tabs": "^6.0.2",
+    "yaml": "^2.8.0"
   }
 }

--- a/src/scripts/generate-sitemap.sh
+++ b/src/scripts/generate-sitemap.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+INPUT_FILE="data/data.yaml"
+OUTPUT_FILE="public/sitemap.txt"
+
+# Extract lines with 'webpage:' and clean them up
+grep 'webpage:' "$INPUT_FILE" \
+  | sed -E 's/.*webpage: *//' \
+  | tr -d '\r' \
+  | sort > "$OUTPUT_FILE"
+
+echo "✅ sitemap.txt created at $OUTPUT_FILE"


### PR DESCRIPTION
Hello @ariostas 

I would like to contribute to the training center as I am currently deploying a training catalog at CERN which will fetch material from the HSF training center. In order to do that I need the providers (you / HSF training center) to have a [sitemap](https://tess.elixir-europe.org/about/registering#sitemaps) at the root of the website. 

What I provided in the PR:
* a simple bash script to create a `sitemap.txt` under `public` listing all the URLs/materials the HSF training center has.
* amended `package.json` so that when developing and deploying the website, it executes the script.

Cheers