### PR TITLE
UI: Open external links in a new tab

### DIFF
--- a/src/components/tutcard.js
+++ b/src/components/tutcard.js
@@ -49,6 +49,7 @@ const Tutcard = ({ tut }) => {
             href={tut.repository}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
           >
             <AiFillGithub height={300} />
             <span style={{ marginLeft: "8px" }}>GitHub</span>
@@ -62,6 +63,7 @@ const Tutcard = ({ tut }) => {
             href={tut.videos}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
           >
             <MdVideoLibrary height={300} />
             <span style={{ marginLeft: "8px" }}>Videos</span>
@@ -87,6 +89,7 @@ const Tutcard = ({ tut }) => {
           href={tut.webpage}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
         >
           <h3>{parse(tut.name)}</h3>
         </a>

--- a/src/components/tutcard.js
+++ b/src/components/tutcard.js
@@ -13,7 +13,7 @@ const images = require.context("../images");
 // markup
 const Tutcard = ({ tut }) => {
   const handleCardClick = () => {
-    window.location.href = tut.webpage;
+    window.open(tut.webpage, "_blank", "noopener,noreferrer");
   };
   const handleCardKeyPress = (e) => {
     if (e.key === "Enter") {
@@ -44,7 +44,7 @@ const Tutcard = ({ tut }) => {
       {/* GitHub and Videos links */}
       <div className="additionals">
         {tut.repository !== "" ? (
-          <a title="GitHub Repo" href={tut.repository}>
+          <a title="GitHub Repo" href={tut.repository} target="_blank" rel="noopener noreferrer">
             <AiFillGithub height={300} />
             <span style={{ marginLeft: "8px" }}>GitHub</span>
           </a>
@@ -52,7 +52,7 @@ const Tutcard = ({ tut }) => {
       </div>
       <div className="videos">
         {tut.videos !== "" ? (
-          <a title="Videos" href={tut.videos}>
+          <a title="Videos" href={tut.videos} target="_blank" rel="noopener noreferrer">
             <MdVideoLibrary height={300} />
             <span style={{ marginLeft: "8px" }}>Videos</span>
           </a>
@@ -72,7 +72,7 @@ const Tutcard = ({ tut }) => {
       {/* texts */}
       <div className="tutCardText">
         {/* title */}
-        <a title={tut.name} href={tut.webpage}>
+        <a title={tut.name} href={tut.webpage} target="_blank" rel="noopener noreferrer">
           <h3>{parse(tut.name)}</h3>
         </a>
 

--- a/src/components/tutcard.js
+++ b/src/components/tutcard.js
@@ -54,10 +54,18 @@ const Tutcard = ({ tut }) => {
             <AiFillGithub height={300} />
             <span style={{ marginLeft: "8px" }}>
               GitHub
-              <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-                <polyline points="15 3 21 3 21 9"/>
-                <line x1="10" y1="14" x2="21" y2="3"/>
+              <svg
+                aria-hidden="true"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
               </svg>
             </span>
           </a>
@@ -75,10 +83,18 @@ const Tutcard = ({ tut }) => {
             <MdVideoLibrary height={300} />
             <span style={{ marginLeft: "8px" }}>
               Videos
-              <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-                <polyline points="15 3 21 3 21 9"/>
-                <line x1="10" y1="14" x2="21" y2="3"/>
+              <svg
+                aria-hidden="true"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
               </svg>
             </span>
           </a>

--- a/src/components/tutcard.js
+++ b/src/components/tutcard.js
@@ -13,7 +13,7 @@ const images = require.context("../images");
 // markup
 const Tutcard = ({ tut }) => {
   const handleCardClick = () => {
-    window.open(tut.webpage, "_blank", "noopener,noreferrer");
+    window.open(tut.webpage, "_blank", "noopener");
   };
   const handleCardKeyPress = (e) => {
     if (e.key === "Enter") {
@@ -48,11 +48,18 @@ const Tutcard = ({ tut }) => {
             title="GitHub Repo"
             href={tut.repository}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             onClick={(e) => e.stopPropagation()}
           >
             <AiFillGithub height={300} />
-            <span style={{ marginLeft: "8px" }}>GitHub</span>
+            <span style={{ marginLeft: "8px" }}>
+              GitHub
+              <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                <polyline points="15 3 21 3 21 9"/>
+                <line x1="10" y1="14" x2="21" y2="3"/>
+              </svg>
+            </span>
           </a>
         ) : null}
       </div>
@@ -62,11 +69,18 @@ const Tutcard = ({ tut }) => {
             title="Videos"
             href={tut.videos}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             onClick={(e) => e.stopPropagation()}
           >
             <MdVideoLibrary height={300} />
-            <span style={{ marginLeft: "8px" }}>Videos</span>
+            <span style={{ marginLeft: "8px" }}>
+              Videos
+              <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                <polyline points="15 3 21 3 21 9"/>
+                <line x1="10" y1="14" x2="21" y2="3"/>
+              </svg>
+            </span>
           </a>
         ) : null}
       </div>
@@ -88,7 +102,7 @@ const Tutcard = ({ tut }) => {
           title={tut.name}
           href={tut.webpage}
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
           onClick={(e) => e.stopPropagation()}
         >
           <h3>{parse(tut.name)}</h3>

--- a/src/components/tutcard.js
+++ b/src/components/tutcard.js
@@ -44,7 +44,12 @@ const Tutcard = ({ tut }) => {
       {/* GitHub and Videos links */}
       <div className="additionals">
         {tut.repository !== "" ? (
-          <a title="GitHub Repo" href={tut.repository} target="_blank" rel="noopener noreferrer">
+          <a
+            title="GitHub Repo"
+            href={tut.repository}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <AiFillGithub height={300} />
             <span style={{ marginLeft: "8px" }}>GitHub</span>
           </a>
@@ -52,7 +57,12 @@ const Tutcard = ({ tut }) => {
       </div>
       <div className="videos">
         {tut.videos !== "" ? (
-          <a title="Videos" href={tut.videos} target="_blank" rel="noopener noreferrer">
+          <a
+            title="Videos"
+            href={tut.videos}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <MdVideoLibrary height={300} />
             <span style={{ marginLeft: "8px" }}>Videos</span>
           </a>
@@ -72,7 +82,12 @@ const Tutcard = ({ tut }) => {
       {/* texts */}
       <div className="tutCardText">
         {/* title */}
-        <a title={tut.name} href={tut.webpage} target="_blank" rel="noopener noreferrer">
+        <a
+          title={tut.name}
+          href={tut.webpage}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <h3>{parse(tut.name)}</h3>
         </a>
 

--- a/src/pages/contribute.js
+++ b/src/pages/contribute.js
@@ -32,8 +32,6 @@ const ContributePage = () => {
           <a
             href="https://hepsoftwarefoundation.org/activities/training.html"
             className="a-no-style"
-            target="_blank"
-            rel="noopener noreferrer"
           >
             main page
           </a>
@@ -41,12 +39,7 @@ const ContributePage = () => {
         </li>
         <li>
           <b>Bugs reports or feature requests</b>: Directly open an issue on{" "}
-          <a
-            href="https://github.com/hsf-training"
-            className="a-no-style"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href="https://github.com/hsf-training" className="a-no-style">
             GitHub
           </a>{" "}
           or (even better) submit a pull request to fix things.
@@ -57,8 +50,6 @@ const ContributePage = () => {
           <a
             href="https://hepsoftwarefoundation.org/training/module-guidelines.html"
             className="a-no-style"
-            target="_blank"
-            rel="noopener noreferrer"
           >
             here
           </a>
@@ -67,8 +58,6 @@ const ContributePage = () => {
           <a
             href="https://github.com/hsf-training/carpentry-cookiecutter"
             className="a-no-style"
-            target="_blank"
-            rel="noopener noreferrer"
           >
             creating a new module
           </a>
@@ -79,8 +68,6 @@ const ContributePage = () => {
           <a
             href="https://hepsoftwarefoundation.org/training/educators.html"
             className="a-no-style"
-            target="_blank"
-            rel="noopener noreferrer"
           >
             More information on the different roles in our training events
           </a>
@@ -90,8 +77,6 @@ const ContributePage = () => {
           <a
             href="https://hepsoftwarefoundation.org/training/howto-event.html"
             className="a-no-style"
-            target="_blank"
-            rel="noopener noreferrer"
           >
             We got you covered
           </a>

--- a/src/pages/contribute.js
+++ b/src/pages/contribute.js
@@ -32,6 +32,8 @@ const ContributePage = () => {
           <a
             href="https://hepsoftwarefoundation.org/activities/training.html"
             className="a-no-style"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             main page
           </a>
@@ -39,7 +41,12 @@ const ContributePage = () => {
         </li>
         <li>
           <b>Bugs reports or feature requests</b>: Directly open an issue on{" "}
-          <a href="https://github.com/hsf-training" className="a-no-style">
+          <a 
+            href="https://github.com/hsf-training" 
+            className="a-no-style"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             GitHub
           </a>{" "}
           or (even better) submit a pull request to fix things.
@@ -50,6 +57,8 @@ const ContributePage = () => {
           <a
             href="https://hepsoftwarefoundation.org/training/module-guidelines.html"
             className="a-no-style"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             here
           </a>
@@ -58,6 +67,8 @@ const ContributePage = () => {
           <a
             href="https://github.com/hsf-training/carpentry-cookiecutter"
             className="a-no-style"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             creating a new module
           </a>
@@ -68,6 +79,8 @@ const ContributePage = () => {
           <a
             href="https://hepsoftwarefoundation.org/training/educators.html"
             className="a-no-style"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             More information on the different roles in our training events
           </a>
@@ -77,6 +90,8 @@ const ContributePage = () => {
           <a
             href="https://hepsoftwarefoundation.org/training/howto-event.html"
             className="a-no-style"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             We got you covered
           </a>

--- a/src/pages/contribute.js
+++ b/src/pages/contribute.js
@@ -41,8 +41,8 @@ const ContributePage = () => {
         </li>
         <li>
           <b>Bugs reports or feature requests</b>: Directly open an issue on{" "}
-          <a 
-            href="https://github.com/hsf-training" 
+          <a
+            href="https://github.com/hsf-training"
             className="a-no-style"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
Resolves #57

Hi team, 

This PR adds `target="_blank"` and `rel="noopener noreferrer"` to external links across the `training-center` so they open in a new tab as requested. 

I've updated:
- The external GitHub, Videos, and Website links on the tutorial cards.
- The tutorial card's direct click event to use `window.open` with `_blank`.
- All external links in the `contribute.js` page.

Let me know if there's any other links you'd like me to catch!